### PR TITLE
Make fork notes more obvious

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+A fork of [mweiss/elm-rte-toolkit](https://package.elm-lang.org/packages/mweiss/elm-rte-toolkit/1.0.4/) with:
+
+-   bug fix PRs from original repo merged
+-   the toolkit expanded with more common helpers & examples
+
 # Rich Text Editor Toolkit
 
 Create rich text editors in Elm.
@@ -107,12 +112,3 @@ and
 ```sh
 npm run dev:review
 ```
-
-# Notes
-
-This was forked from https://github.com/mweiss/elm-rte-toolkit.
-
-### Goals
-
--   merge known bug fixes
--   expand the toolkit with more common helpers & examples

--- a/elm.json
+++ b/elm.json
@@ -1,7 +1,7 @@
 {
     "type": "package",
     "name": "wolfadex/elm-rte-toolkit",
-    "summary": "Build rich text editors in Elm",
+    "summary": "Build rich text editors in Elm (fork of mweiss/elm-rte-toolkit)",
     "license": "BSD-3-Clause",
     "version": "1.0.0",
     "exposed-modules": [


### PR DESCRIPTION
This should make it obvious it's a fork even in the search results list on package.elm-lang.org. Plus the readme has it on top instead of at the bottom. I suspect many people searching for `elm-rte-toolkit` will end up asking that question of "why choose this over the original"